### PR TITLE
Add configuration for MTM2. 

### DIFF
--- a/MTM2/v1/_labels.yaml
+++ b/MTM2/v1/_labels.yaml
@@ -1,0 +1,1 @@
+# there are no standard M2 configurations yet


### PR DESCRIPTION
This is a salobj component that is currently only a skeleton. We may want to turn that into a simulator or even the real deal in the future.