### PR TITLE
MTHexapod: add missing reference_position data

### DIFF
--- a/MTHexapod/v1/default.yaml
+++ b/MTHexapod/v1/default.yaml
@@ -32,6 +32,7 @@ camera_config:
     - [0]
   min_temperature: -20
   max_temperature: 20
+  reference_position: [0, 0, 0, 0, 0, 0]
 m2_config:
   elevation_coeffs:
     # Fit of https://github.com/bxin/hexrot/blob/master/LUT/M2%20Hexapod%20Motions%20in%20Elevation%20Axis%202020%2007%2023.xlsx
@@ -66,4 +67,5 @@ m2_config:
     - [0]
   min_temperature: -20
   max_temperature: 20
+  reference_position: [0, 0, 0, 0, 0, 0]
 


### PR DESCRIPTION
this is needed with ts_mthexapod v0.13.0, which uses ts_xml 7.1.
It must be removed for versions of ts_mthexapod that use ts_xml 7.2