### PR TITLE
Fix MTDomeTrajectory test

### DIFF
--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -57,7 +57,7 @@ class ConfigTestCase(salobj.BaseConfigTestCase, unittest.TestCase):
     def test_MTDomeTrajectory(self):
         self.check_standard_config_files(
             sal_name="MTDomeTrajectory",
-            package_name="ts_MTDomeTrajectory",
+            module_name="lsst.ts.MTDomeTrajectory",
             schema_name="CONFIG_SCHEMA",
             config_package_root=self.config_package_root,
         )


### PR DESCRIPTION
One must use module_name instead of package_name to use the schema_name argument.