### PR TITLE
Update the _init.yaml of MTHexapod.

### DIFF
--- a/MTHexapod/v4/_init.yaml
+++ b/MTHexapod/v4/_init.yaml
@@ -91,8 +91,7 @@ camera_config:
   min_temperature: -20
   max_temperature: 20
   enable_lut_temperature: False
-  high_current_threshold: 4.5
-  no_movement_timeout: 1200
+  no_movement_idle_time: 1200
   camera: 'CCCamera'
   filter_offsets:
     r_03:
@@ -192,7 +191,6 @@ m2_config:
   min_temperature: -20
   max_temperature: 20
   enable_lut_temperature: False
-  high_current_threshold: 4.5
-  no_movement_timeout: 1200
+  no_movement_idle_time: 1200
   host: localhost
   port: 5550

--- a/MTHexapod/v4/_init.yaml
+++ b/MTHexapod/v4/_init.yaml
@@ -91,6 +91,8 @@ camera_config:
   min_temperature: -20
   max_temperature: 20
   enable_lut_temperature: False
+  high_current_threshold: 4.5
+  no_movement_timeout: 1200
   camera: 'CCCamera'
   filter_offsets:
     r_03:
@@ -190,5 +192,7 @@ m2_config:
   min_temperature: -20
   max_temperature: 20
   enable_lut_temperature: False
+  high_current_threshold: 4.5
+  no_movement_timeout: 1200
   host: localhost
   port: 5550


### PR DESCRIPTION
Add the `high_current_threshold` and `no_movement_timeout` fields.