### PR TITLE
MTHexapod: Add idle_during_visit.yaml configuration.

### DIFF
--- a/MTHexapod/v7/idle_during_visit.yaml
+++ b/MTHexapod/v7/idle_during_visit.yaml
@@ -1,0 +1,4 @@
+camera_config:
+   no_movement_idle_time: 10 
+m2_config:
+   no_movement_idle_time: 10


### PR DESCRIPTION
This configuration set will configure both hexapods to power down the drivers after ~5s~ 10s of idle time.